### PR TITLE
Linux: Fix build & segfault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@
 x64/
 Win32/
 /VisualC_net/.vs
+
+# Unix build artifacts
+bin/RNG_benchmark
+bin/RNG_output
+bin/RNG_test
+bin/Test_calibration

--- a/src/test_batteries.cpp
+++ b/src/test_batteries.cpp
@@ -25,8 +25,8 @@
 #include "PractRand/Tests/CoupGap.h"
 #include "PractRand/Tests/BRank.h"
 #include "PractRand/Tests/mod3.h"
-#include "PractRand/Tests/NearSeq.h"
-#include "PractRand/Tests/Coup16.h"
+#include "PractRand/Tests/nearseq.h"
+#include "PractRand/Tests/coup16.h"
 #include "PractRand/Tests/DistFreq4.h"
 #include "PractRand/Tests/transforms.h"
 

--- a/tools/RNG_from_name.h
+++ b/tools/RNG_from_name.h
@@ -307,6 +307,7 @@ namespace RNG_Factories {
 				return new PractRand::RNGs::Polymorphic::NotRecommended::xlcg32of64_varqual(total_bits - out_bits);
 			else return new PractRand::RNGs::Polymorphic::NotRecommended::xlcg32of128_varqual(total_bits - out_bits);
 		}
+		return NULL;
 	}
 	PractRand::RNGs::vRNG *clcg_factory(std::vector<std::string> &params) {
 		if (params.size() != 2) {params.push_back("wrong number of parameters to clcg - should be clcg(out_bits,total_bits)");return NULL;}

--- a/tools/RNG_test.cpp
+++ b/tools/RNG_test.cpp
@@ -294,7 +294,7 @@ double print_result(const PractRand::TestResult &result, bool print_header = fal
 
 const char *seed_str = NULL;
 
-double show_checkpoint(TestManager *tman, int mode, Uint64 seed, double time, bool smart_thresholds, double threshold, bool end_on_failure) {
+void show_checkpoint(TestManager *tman, int mode, Uint64 seed, double time, bool smart_thresholds, double threshold, bool end_on_failure) {
 	std::printf("rng=%s", tman->get_rng()->get_name().c_str());
 
 	std::printf(", seed=");

--- a/tools/RNG_test.cpp
+++ b/tools/RNG_test.cpp
@@ -453,10 +453,10 @@ bool interpret_seed(const std::string &seedstr, Uint64 &seed) {
 	return true;
 }
 
-#include "PractRand/tests/Birthday.h"
-#include "PractRand/tests/FPMulti.h"
-#include "PractRand/tests/DistFreq4.h"
-#include "PractRand/tests/Gap16.h"
+#include "PractRand/Tests/birthday.h"
+#include "PractRand/Tests/FPMulti.h"
+#include "PractRand/Tests/DistFreq4.h"
+#include "PractRand/Tests/Gap16.h"
 PractRand::Tests::ListOfTests testset_BirthdaySystematic() {
 	//return PractRand::Tests::ListOfTests(new PractRand::Tests::FPMulti(3,0));
 	//return PractRand::Tests::ListOfTests(new PractRand::Tests::BirthdayAlt(10), new PractRand::Tests::Birthday32());


### PR DESCRIPTION
Two fixes:
* Corrects #include paths for case-sensitive file systems [(known issue)](https://sourceforge.net/p/pracrand/bugs/11/)
* Fixes SegFault on GCC due to missing return values [(known issue)](https://sourceforge.net/p/pracrand/bugs/15/)

Also added the unix build artifacts to .gitignore.